### PR TITLE
chore: delete SECURITY.md to use organization-wide policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,0 @@
-# Security Policy
-
-Thanks for your interest in the security of our products. 
-
-Our official security policy and vulnerability reporting instructions can be found at: https://www.elastic.co/product-security  
-
-_Please do not report security vulnerabilities via GitHub Issues._
-


### PR DESCRIPTION
~This PR deletes the repository-specific SECURITY.md file to consolidate to a single source of truth for the security policy, which is https://github.com/elastic/.github/blob/main/SECURITY.md. Since this is the `.github` repo, this will cause the default to be used.~

Automation opened this in error.